### PR TITLE
Add queryset object as wrapper to pymongo cursor

### DIFF
--- a/pyjo_mongo/queryset.py
+++ b/pyjo_mongo/queryset.py
@@ -1,0 +1,53 @@
+from bson import ObjectId
+
+__author__ = 'xelhark'
+
+
+class Queryset(object):
+    def __init__(self, cls, cursor=None):
+        self.cls = cls
+        self._cursor = cursor
+
+    @property
+    def cursor(self):
+        return self._cursor or self.cls._get_collection()
+
+    def with_id(self, id):
+        id = ObjectId(id) if not isinstance(id, ObjectId) else id
+        return self.find_one({'_id': id})
+
+    def with_ids(self, ids):
+        if not isinstance(ids, list):
+            raise Exception('argument must be a list')
+        ids = [ObjectId(id) if not isinstance(id, ObjectId) else id for id in ids]
+        return self.find({'_id': {'$in': ids}})
+
+    def find(self, *args, **kwargs):
+        if self._cursor is not None:
+            raise RuntimeError("Chaining find methods is not supported")
+        return Queryset(cls=self.cls, cursor=self.cls._get_collection().find(*args, **kwargs))
+
+    def find_one(self, *args, **kwargs):
+        """
+        Finds and returns a single instance of the requested document class, matching the criteria provided
+        :param args: args sent to Mongo for filtering
+        :param kwargs: kwargs sent to Mongo for filtering
+        :return: The instance of document class requested or None, if not found
+        :rtype: cls
+        """
+        data = self.cursor.find_one(*args, **kwargs)
+        if data:
+            return self.cls.from_dict(data)
+
+    def count(self):
+        return self.cursor.count()
+
+    def __getitem__(self, item):
+        return self.cls.from_dict(self.cursor[item])
+
+    def __iter__(self):
+        for element in self.cursor:
+            yield self.cls.from_dict(element)
+
+    def __next__(self):
+        return self.cls.from_dict(self.cursor.__next___())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,29 @@ __author__ = 'gabriele'
 
 
 @pytest.fixture()
+def users():
+    for index in range(5):
+        User(
+            username='test{}'.format(index),
+            first_name='guy',
+            last_name='bar',
+            age=index + 18,
+            gender=Gender.male,
+        ).save()
+
+    for index in range(5):
+        User(
+            username='foo{}'.format(index),
+            first_name='girl',
+            last_name='bar',
+            age=index + 18,
+            gender=Gender.female,
+        ).save()
+
+    return User.objects.find()
+
+
+@pytest.fixture()
 def user():
     user = User(
         username='test',
@@ -110,3 +133,17 @@ def test_model_no_indexes():
     t_model.save()
 
     assert ModelWithNoIndexes.objects.count() == 1
+
+
+def test_queryset_chaining(users):
+    assert User.objects.count() == 10
+    assert User.objects.find({'gender': Gender.male.name}).count() == 5
+    assert User.objects.find({'gender': Gender.female.name}).count() == 5
+
+
+def test_can_iterate_results(users):
+    count = 0
+    for u in User.objects.find({'gender': Gender.male.name}):
+        assert u.gender is Gender.male
+        count += 1
+    assert count == 5


### PR DESCRIPTION
Backward compatible change. Check test cases to see how it works. It's now possible to chain `.count()` to results and iterate over results. 